### PR TITLE
Improvement: Aliases for modules for example to support modules from "node_modules" with special characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var Injector = function (injectorName, args) {
     this.modules = {};
     this.constants = constants;
     this.mockedModules = _args.mock;
+    this.aliases = _args.aliases || {};
     
     assert.notEqual(typeof _args.directory, 'function', 'Directory must be an array or a string');
     assert.notEqual(typeof this.modulesDirectory.indexOf, 'undefined', 'Directory cannot be an object');
@@ -87,10 +88,18 @@ Injector.prototype.register = function (args, override) {
         throw new Error('Tried to overwrite "' + args.name + '". ' + _errMsg);
     }
     
+    var dependsOn = args.dependsOn || [];
+    for (var k in dependsOn) {
+        var alias = this.aliases[dependsOn[k]];
+        if (alias) {
+            dependsOn[k] = alias;
+        }
+    }
+
     this.modules[args.name] = {
         name: args.name,
         definition: args.definition,
-        dependsOn: args.dependsOn || [],
+        dependsOn: dependsOn,
         bootstrapped: constants.NOT_BOOSTRAPPED
     };
     
@@ -125,7 +134,7 @@ Injector.prototype.resolveDependencies = function (moduleDeps) {
 
 Injector.prototype.parse = function (module) {
     var self = this;
-    
+
     if (typeof module.definition !== 'function') {
         module.bootstrapped = module.definition;
     }


### PR DESCRIPTION
Hi,

my first pull request, but I hope it will works to send you a little improvement to your greate project. :)
## Introduction

The injector allows to load modules from "node_modules" per inject and per defining as dependency.
So:

``` javascript
var dependency = require('dependency');
exports.module = function () {};
```

Is the same as:

``` javascript
exports.module = function (inject) {
    var dependency = inject('dependency');
};
```

And the same as:

``` javascript
exports.module = function (dependency) {};
```
## Problem

But the problem are modules with special characters in the name, like "body-parser" (connector extension for express).

So this will not work, its a syntax error:

``` javascript
exports.module = function (body-parser) {};
```
## Solution

Cause of this problem I add the possibility to define aliases for the Injector.

So with this feature you can add aliases to the injector configuration:

``` javascript
Injector.create('', {
    aliases: {
        bodyParser: 'body-parser'
    }
});
```

And now use the alias as dependency for modules:

``` javascript
exports.module = function (bodyParser) {};
```
## Implementation

I add the aliases to the register method and replace the names in the dependency configuration of the modules. This was the only central location I found to check and replace the aliases for both types of modules (parsed modules and modules from "node_modules").

But if you find a better location feel free. :)
